### PR TITLE
[DO NOT MERGE] Self-use one-click run

### DIFF
--- a/scripts/config_models.sh
+++ b/scripts/config_models.sh
@@ -45,6 +45,11 @@ MODEL_SELECT() {
             MODEL_TEMPLATE_TYPE="meta-chat"
             MODEL_FRAMEWORK="sglang"
             ;;
+        mixtral-8x7b-instruct-v0.1)
+            MODEL_PATH="mistralai/Mixtral-8x7B-Instruct-v0.1"
+            MODEL_TEMPLATE_TYPE="base"
+            MODEL_FRAMEWORK="sglang"
+            ;;
         gpt-3.5-turbo)
             MODEL_PATH="gpt-3.5-turbo-0125"
             MODEL_TEMPLATE_TYPE="base"

--- a/scripts/config_models.sh
+++ b/scripts/config_models.sh
@@ -30,10 +30,20 @@ MODEL_SELECT() {
     ENGINE_DIR=$3
     
     case $MODEL_NAME in
-        llama2-7b-chat)
-            MODEL_PATH="${MODEL_DIR}/llama2-7b-chat-hf"
+        llama3.1-405b-instruct)
+            MODEL_PATH="meta-llama/Meta-Llama-3.1-405B-Instruct"
             MODEL_TEMPLATE_TYPE="meta-chat"
-            MODEL_FRAMEWORK="vllm"
+            MODEL_FRAMEWORK="sglang"
+            ;;
+        llama3.1-405b-instruct-fp8)
+            MODEL_PATH="meta-llama/Meta-Llama-3.1-405B-Instruct-FP8"
+            MODEL_TEMPLATE_TYPE="meta-chat"
+            MODEL_FRAMEWORK="sglang"
+            ;;
+        llama3.1-8b-instruct)
+            MODEL_PATH="meta-llama/Meta-Llama-3.1-8B-Instruct"
+            MODEL_TEMPLATE_TYPE="meta-chat"
+            MODEL_FRAMEWORK="sglang"
             ;;
         gpt-3.5-turbo)
             MODEL_PATH="gpt-3.5-turbo-0125"

--- a/scripts/config_tasks.sh
+++ b/scripts/config_tasks.sh
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-NUM_SAMPLES=500
+NUM_SAMPLES=100
 REMOVE_NEWLINE_TAB=false
 STOP_WORDS=""
 

--- a/scripts/pred/call_api.py
+++ b/scripts/pred/call_api.py
@@ -73,7 +73,7 @@ parser.add_argument("--chunk_amount", type=int, default=1, help='size of split c
 # Server
 parser.add_argument("--server_type", default='nemo', action=ServerAction, choices=SERVER_TYPES)
 parser.add_argument("--server_host", type=str, default='127.0.0.1')
-parser.add_argument("--server_port", type=str, default='5000')
+parser.add_argument("--server_port", type=str, default='30000')
 parser.add_argument("--ssh_server", type=str)
 parser.add_argument("--ssh_key_path", type=str)
 parser.add_argument("--model_name_or_path", type=str, default='gpt-3.5-turbo', 

--- a/scripts/pred/client_wrappers.py
+++ b/scripts/pred/client_wrappers.py
@@ -184,6 +184,44 @@ class SGLClient(Client):
         outputs = outputs['text']
         return outputs
 
+    # async def _send_request(
+    #     self, prompts, tokens_to_generate, temperature, top_p, top_k, random_seed, stop: List[str],
+    # ):
+    #     headers = {"User-Agent": "Benchmark Client"}
+    #     params = {
+    #         "max_new_tokens": tokens_to_generate,
+    #         "temperature": temperature,
+    #         "top_k": top_k,
+    #         "top_p": top_p,
+    #         "stop": stop,
+    #     }
+    #     pload = {
+    #         "text": prompts[0],
+    #         "sampling_params": params,
+    #     }
+
+    #     api_url = api_url = f"{self.server_host}:{self.server_port}/generate"
+
+    #     timeout = aiohttp.ClientTimeout(total=3 * 3600)
+    #     async with aiohttp.ClientSession(timeout=timeout) as session:
+    #         while True:
+    #             async with session.post(
+    #                 api_url, headers=headers, json=pload
+    #             ) as response:
+    #                 chunks = []
+    #                 async for chunk, _ in response.content.iter_chunks():
+    #                     chunks.append(chunk)
+    #             output = b"".join(chunks).decode("utf-8")
+    #             output = json.loads(output)
+
+    #             # Re-send the request if it failed.
+    #             if "error" not in output:
+    #                 break
+    #             else:
+    #                 print(output)
+    #     output = output['text']
+    #     return output
+
 
 class OpenAIClient:
     def __init__(

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -24,7 +24,6 @@ fi
 
 # Root Directories
 GPUS="1" # GPU size for tensor_parallel.
-ROOT_DIR="benchmark_root" # the path that stores generated task samples and model predictions.
 MODEL_DIR="../.." # the path that contains individual model folders from HUggingface.
 ENGINE_DIR="." # the path that contains individual engine folders from TensorRT-LLM.
 BATCH_SIZE=1000  # increase to improve GPU utilization
@@ -57,6 +56,7 @@ if [ -z "${TASKS}" ]; then
     exit 1
 fi
 
+ROOT_DIR="benchmark_root/${NUM_SAMPLES}samples" # the path that stores generated task samples and model predictions.
 SEQ_LENGTHS=(
     # 131072
     128000

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -27,7 +27,7 @@ GPUS="1" # GPU size for tensor_parallel.
 ROOT_DIR="benchmark_root" # the path that stores generated task samples and model predictions.
 MODEL_DIR="../.." # the path that contains individual model folders from HUggingface.
 ENGINE_DIR="." # the path that contains individual engine folders from TensorRT-LLM.
-BATCH_SIZE=1  # increase to improve GPU utilization
+BATCH_SIZE=1000  # increase to improve GPU utilization
 
 
 # Model and Tokenizer
@@ -57,31 +57,40 @@ if [ -z "${TASKS}" ]; then
     exit 1
 fi
 
+SEQ_LENGTHS=(
+    # 131072
+    128000
+    65536
+    32768
+    16384
+    8192
+    4096
+)
 
 # Start server (you may want to run in other container.)
-if [ "$MODEL_FRAMEWORK" == "vllm" ]; then
-    python pred/serve_vllm.py \
-        --model=${MODEL_PATH} \
-        --tensor-parallel-size=${GPUS} \
-        --dtype bfloat16 \
-        --disable-custom-all-reduce \
-        &
-
-elif [ "$MODEL_FRAMEWORK" == "trtllm" ]; then
-    python pred/serve_trt.py \
-        --model_path=${MODEL_PATH} \
-        &
-
-elif [ "$MODEL_FRAMEWORK" == "sglang" ]; then
-    python -m sglang.launch_server \
-        --model-path ${MODEL_PATH} \
-        --tp ${GPUS} \
-        --port 5000 \
-        --enable-flashinfer \
-        &
-    # use sglang/test/killall_sglang.sh to kill sglang server if it hangs
-
-fi
+# if [ "$MODEL_FRAMEWORK" == "vllm" ]; then
+#     python pred/serve_vllm.py \
+#         --model=${MODEL_PATH} \
+#         --tensor-parallel-size=${GPUS} \
+#         --dtype bfloat16 \
+#         --disable-custom-all-reduce \
+#         &
+# 
+# elif [ "$MODEL_FRAMEWORK" == "trtllm" ]; then
+#     python pred/serve_trt.py \
+#         --model_path=${MODEL_PATH} \
+#         &
+# 
+# elif [ "$MODEL_FRAMEWORK" == "sglang" ]; then
+#     python -m sglang.launch_server \
+#         --model-path ${MODEL_PATH} \
+#         --tp ${GPUS} \
+#         --port 5000 \
+#         --enable-flashinfer \
+#         &
+#     # use sglang/test/killall_sglang.sh to kill sglang server if it hangs
+# 
+# fi
 
 
 # Start client (prepare data / call model API / obtain final metrics)

--- a/scripts/summary.py
+++ b/scripts/summary.py
@@ -7,10 +7,12 @@ import pandas as pd
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--avg_score-dir", type=str, default="benchmark_root")
+    parser.add_argument("--num-sample", type=int, default=100)
     args = parser.parse_args()
 
     models = [
         "mistral-7b-instruct-v0.2",
+        "llama3.1-8b-instruct",
         "llama3.1-405b-instruct",
         "llama3.1-405b-instruct-fp8",
     ]
@@ -19,7 +21,7 @@ if __name__ == "__main__":
     
     for model in models:
         avg_score[model] = {}
-        dirpath = os.path.join(args.avg_score_dir, f"{model}/synthetic")
+        dirpath = os.path.join(args.avg_score_dir, f"{args.num_sample}samples/{model}/synthetic")
         for filename in glob.glob(f"{dirpath}/**/pred/summary.csv", recursive=True):
             seqlen = int(filename.split("/")[-3])
             with open(filename, "r") as f:

--- a/scripts/summary.py
+++ b/scripts/summary.py
@@ -1,0 +1,33 @@
+import argparse
+import glob
+import os
+import pandas as pd
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--avg_score-dir", type=str, default="benchmark_root")
+    args = parser.parse_args()
+
+    models = [
+        "mistral-7b-instruct-v0.2",
+        "llama3.1-405b-instruct",
+        "llama3.1-405b-instruct-fp8",
+    ]
+    
+    avg_score = {}
+    
+    for model in models:
+        avg_score[model] = {}
+        dirpath = os.path.join(args.avg_score_dir, f"{model}/synthetic")
+        for filename in glob.glob(f"{dirpath}/**/pred/summary.csv", recursive=True):
+            seqlen = int(filename.split("/")[-3])
+            with open(filename, "r") as f:
+                df = pd.read_csv(f) 
+                avg = df.iloc[1][1:].astype(float).mean()
+                avg_score[model][seqlen] = avg
+                print(filename)
+                print(df.to_string(index=False, header=False))
+    
+    avg_score = {k: dict(sorted(v.items(), key=lambda x: x[0])) for k, v in avg_score.items()}
+    print("average score", avg_score)


### PR DESCRIPTION
Install:
```
pip install cython
pip install pandas pyannote.metrics jiwer tenacity youtokentome librosa pytorch-lightning hydra-core nemo_toolkit wonderwords transformers sentencepiece inflect editdistance lhotse webdataset datasets psutil uvicorn uvloop fastapi outlines rpyc zmq nltk html2text bs4 ipython huggingface_hub==0.23.2
```
Download data:
```
cd scripts/data/synthetic/json/
python download_paulgraham_essay.py
bash download_qa_dataset.sh
```


Launch server for 405b fp16:
```
# on the first node
GLOO_SOCKET_IFNAME=eth0 python3 -m sglang.launch_server --model-path meta-llama/Meta-Llama-3.1-405B-Instruct --tp 16 --nccl-init-addr $MASTER_ADDR:20000 --nnodes 2 --node-rank 0 --disable-cuda-graph --mem-frac 0.8 --disable-flashinfer-sampling --chunked-prefill-size 8192
# on the second node
GLOO_SOCKET_IFNAME=eth0 python3 -m sglang.launch_server --model-path meta-llama/Meta-Llama-3.1-405B-Instruct --tp 16 --nccl-init-addr $MASTER_ADDR:20000 --nnodes 2 --node-rank 1 --disable-cuda-graph --mem-frac 0.8 --disable-flashinfer-sampling --chunked-prefill-size 8192
```
Run:
```
bash run.sh llama3.1-405b-instruct synthetic
```

See results:
```
python summary.py
```

Notes:
1. If you want to run for a different model, add the model path (huggingface or local) to `config_models.sh`.
2. Set the `NUM_SAMPLES` to the number of samples you want to run for each setting in `config_tasks.sh`.
3. If you are running a small model which only requires 1 GPU, but you have a node of 8 GPUs, you can turn on `--dp 8` to accelerate the evaluation.